### PR TITLE
Enhance vm-virtio crate to better support fuse/virtiofs related projects

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,9 @@ byteorder = "=1.2.1"
 epoll = "=4.0.1"
 libc = ">=0.2.39"
 log = "=0.4.6"
-vm-memory = ">=0.2.0"
+vm-memory = {version = ">=0.2.0", features = ["integer-atomics"] }
 vmm-sys-util = ">=0.4.0"
 
 [dev-dependencies.vm-memory]
 version = ">=0.2.0"
-features = ["backend-mmap"]
+features = ["backend-mmap", "integer-atomics"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ edition = "2018"
 
 [dependencies]
 byteorder = "=1.2.1"
-epoll = "=4.0.1"
 libc = ">=0.2.39"
 log = "=0.4.6"
 vm-memory = {version = ">=0.2.0", features = ["integer-atomics"] }

--- a/coverage_config_aarch64.json
+++ b/coverage_config_aarch64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 81.1,
+  "coverage_score": 82.9,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 84.2,
+  "coverage_score": 87.5,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/src/device.rs
+++ b/src/device.rs
@@ -18,7 +18,7 @@ use vmm_sys_util::eventfd::EventFd;
 /// called and all the events, memory, and queues for device operation will be moved into the
 /// device. Optionally, a virtio device can implement device reset in which it returns said
 /// resources and resets its internal state.
-pub trait VirtioDevice<M: GuestAddressSpace>: Send {
+pub trait VirtioDevice<A: GuestAddressSpace>: Send {
     /// The virtio device type.
     fn device_type(&self) -> u32;
 
@@ -43,10 +43,10 @@ pub trait VirtioDevice<M: GuestAddressSpace>: Send {
     /// Activates this device for real usage.
     fn activate(
         &mut self,
-        mem: M,
+        mem: A,
         interrupt_evt: EventFd,
         status: Arc<AtomicUsize>,
-        queues: Vec<Queue<M>>,
+        queues: Vec<Queue>,
         queue_evts: Vec<EventFd>,
     ) -> ActivateResult;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 #![deny(missing_docs)]
 
 //! Implements virtio devices, queues, and transport mechanisms.
-extern crate epoll;
+
 #[macro_use]
 extern crate log;
 extern crate vm_memory;

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -130,6 +130,8 @@ pub struct DescriptorChain<M: GuestAddressSpace> {
 
     /// The current descriptor
     desc: Descriptor,
+    curr_indirect: Option<Box<DescriptorChain<M>>>,
+    is_master: bool,
 }
 
 impl<M: GuestAddressSpace> DescriptorChain<M> {
@@ -158,6 +160,8 @@ impl<M: GuestAddressSpace> DescriptorChain<M> {
             queue_size,
             ttl,
             desc,
+            curr_indirect: None,
+            is_master: true,
         };
 
         if chain.is_valid() {
@@ -212,6 +216,8 @@ impl<M: GuestAddressSpace> DescriptorChain<M> {
                 flags: desc.flags,
                 next: desc.next,
             },
+            curr_indirect: None,
+            is_master: false,
         };
 
         if !chain.is_valid() {
@@ -274,20 +280,59 @@ impl<M: GuestAddressSpace> Iterator for DescriptorChain<M> {
             return None;
         }
 
-        let curr = self.desc;
-        if !self.has_next() {
-            self.ttl = 0
+        // Special handling for indirect descriptor table
+        if self.is_indirect() {
+            // An indirect descriptor can not refer to another indirect descriptor table
+            if !self.is_master {
+                return None;
+            }
+            if self.curr_indirect.is_none() {
+                let indirect_chain = self.new_from_indirect().ok()?;
+                self.curr_indirect = Some(Box::new(indirect_chain));
+            }
+            // Above code ensures that it's safe to unwrap().
+            let indirect = self.curr_indirect.as_mut().unwrap();
+
+            match indirect.next() {
+                // return the next descriptor from the indirect chain
+                Some(d) => Some(d),
+                // current indirect chain hs reached the end, return to the master chain.
+                None => {
+                    self.curr_indirect = None;
+                    if !self.has_next() {
+                        // the main descriptor has reached the end too.
+                        self.ttl = 0;
+                        None
+                    } else {
+                        // read next descriptor from the main descriptor chain.
+                        let index = self.desc.next;
+                        let offset = index as u64 * VIRTQ_DESCRIPTOR_SIZE as u64;
+                        let addr = self.desc_table.unchecked_add(offset);
+                        let slice = self.mem.get_slice(addr, VIRTQ_DESCRIPTOR_SIZE).ok()?;
+
+                        self.desc = slice.get_ref(0).ok()?.load();
+                        self.ttl -= 1;
+                        self.next()
+                    }
+                }
+            }
         } else {
-            let index = self.desc.next;
-            let desc_table_size = size_of::<Descriptor>() * self.queue_size as usize;
-            let slice = self.mem.get_slice(self.desc_table, desc_table_size).ok()?;
-            self.desc = slice
-                .get_array_ref(0, self.queue_size as usize)
-                .ok()?
-                .load(index as usize);
-            self.ttl -= 1;
+            let curr = self.desc;
+            if !self.has_next() {
+                self.ttl = 0
+            } else {
+                let index = self.desc.next;
+                let desc_table_size = VIRTQ_DESCRIPTOR_SIZE * self.queue_size as usize;
+                let slice = self.mem.get_slice(self.desc_table, desc_table_size).ok()?;
+                self.desc = slice
+                    .get_array_ref(0, self.queue_size as usize)
+                    .ok()?
+                    .load(index as usize);
+                self.ttl -= 1;
+            }
+
+            Some(curr)
         }
-        Some(curr)
     }
 }
 
@@ -913,11 +958,15 @@ pub(crate) mod tests {
         let m = &GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
         let vq = VirtQueue::new(GuestAddress(0), m, 16);
 
-        // create a chain with a descriptor pointing to an indirect table
+        // create a chain with two descriptor pointing to an indirect tables
         let desc = vq.dtable(0);
-        desc.set(0x1000, 0x1000, VIRTQ_DESC_F_INDIRECT, 0);
+        desc.set(0x1000, 0x1000, VIRTQ_DESC_F_INDIRECT | VIRTQ_DESC_F_NEXT, 1);
+        let desc = vq.dtable(1);
+        desc.set(0x2000, 0x1000, VIRTQ_DESC_F_INDIRECT | VIRTQ_DESC_F_NEXT, 2);
+        let desc = vq.dtable(2);
+        desc.set(0x3000, 0x1000, 0, 0);
 
-        let c: DescriptorChain<&GuestMemoryMmap> =
+        let mut c: DescriptorChain<&GuestMemoryMmap> =
             DescriptorChain::checked_new(m, vq.start(), 16, 0).unwrap();
         assert!(c.is_indirect());
 
@@ -929,17 +978,39 @@ pub(crate) mod tests {
         let mut indirect_table = Vec::with_capacity(4 as usize);
         for j in 0..4 {
             let desc = VirtqDesc::new(&dtable, j);
-            desc.set(0x1000, 0x1000, VIRTQ_DESC_F_NEXT, (j + 1) as u16);
+            if j < 3 {
+                desc.set(0x1000, 0x1000, VIRTQ_DESC_F_NEXT, (j + 1) as u16);
+            } else {
+                desc.set(0x1000, 0x1000, 0, 0 as u16);
+            }
             indirect_table.push(desc);
         }
 
-        // try to iterate through the indirect table descriptors
-        let mut i = c.new_from_indirect().unwrap();
+        let dtable2 = region
+            .get_slice(MemoryRegionAddress(0x2000u64), VirtqDesc::dtable_len(1))
+            .unwrap();
+        let desc2 = VirtqDesc::new(&dtable2, 0);
+        desc2.set(0x8000, 0x1000, 0, 0);
+
+        // try to iterate through the first indirect descriptor chain
         for j in 0..4 {
-            let desc = i.next().unwrap();
-            assert_eq!(desc.flags(), VIRTQ_DESC_F_NEXT);
-            assert_eq!(desc.next, j + 1);
+            let desc = c.next().unwrap();
+            if j < 3 {
+                assert_eq!(desc.flags(), VIRTQ_DESC_F_NEXT);
+                assert_eq!(desc.next, j + 1);
+            }
         }
+
+        // try to iterate through the second indirect descriptor chain
+        let desc = c.next().unwrap();
+        assert_eq!(desc.addr(), GuestAddress(0x8000));
+
+        // back to the main descriptor chain
+        let desc = c.next().unwrap();
+        assert_eq!(desc.addr(), GuestAddress(0x3000));
+
+        assert!(c.next().is_none());
+        assert!(c.next().is_none());
     }
 
     #[test]

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -4,9 +4,14 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE-BSD-3-Clause file.
 //
+// Copyright © 2019 Intel Corporation
+//
+// Copyright (C) 2020 Alibaba Cloud. All rights reserved.
+//
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
 use std::cmp::min;
+use std::fmt::{self, Display};
 use std::mem::size_of;
 use std::num::Wrapping;
 use std::sync::atomic::{fence, Ordering};
@@ -18,6 +23,7 @@ use vm_memory::{
 
 pub(super) const VIRTQ_DESC_F_NEXT: u16 = 0x1;
 pub(super) const VIRTQ_DESC_F_WRITE: u16 = 0x2;
+pub(super) const VIRTQ_DESC_F_INDIRECT: u16 = 0x4;
 
 const VIRTQ_USED_ELEMENT_SIZE: usize = 8;
 // Used ring header: flags (u16) + idx (u16)
@@ -42,6 +48,32 @@ const VIRTQ_AVAIL_RING_META_SIZE: usize = VIRTQ_AVAIL_RING_HEADER_SIZE + 2;
 //
 // The Virtio Spec 1.0 defines the alignment of VirtIO descriptor is 16 bytes,
 // which fulfills the explicit constraint of GuestMemory::read_obj().
+const VIRTQ_DESCRIPTOR_SIZE: usize = 16;
+
+/// Virtio Queue related errors.
+#[derive(Debug)]
+pub enum Error {
+    /// Failed to access guest memory.
+    GuestMemoryError,
+    /// Invalid indirect descriptor.
+    InvalidIndirectDescriptor,
+    /// Invalid descriptor chain.
+    InvalidChain,
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use self::Error::*;
+
+        match self {
+            GuestMemoryError => write!(f, "error accessing guest memory"),
+            InvalidChain => write!(f, "invalid descriptor chain"),
+            InvalidIndirectDescriptor => write!(f, "invalid indirect descriptor"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
 
 /// A virtio descriptor constraints with C representation
 #[repr(C)]
@@ -135,6 +167,7 @@ impl<M: GuestAddressSpace> DescriptorChain<M> {
         }
     }
 
+    /// Create a new DescriptorChain instance.
     fn checked_new(
         mem: M::T,
         dtable_addr: GuestAddress,
@@ -142,6 +175,50 @@ impl<M: GuestAddressSpace> DescriptorChain<M> {
         index: u16,
     ) -> Option<Self> {
         Self::read_new(mem, dtable_addr, queue_size, queue_size, index)
+    }
+
+    /// Create a `DescriptorChain` from the indirect target descriptor table.
+    pub fn new_from_indirect(&self) -> Result<DescriptorChain<M>, Error> {
+        if !self.is_indirect() {
+            return Err(Error::InvalidIndirectDescriptor);
+        }
+
+        let desc_head = self.desc.addr;
+        let desc_len = self.desc.len as usize;
+        // Check the target indirect descriptor table is correctly aligned.
+        if desc_head & (VIRTQ_DESCRIPTOR_SIZE as u64 - 1) != 0
+            || desc_len & (VIRTQ_DESCRIPTOR_SIZE - 1) != 0
+            || desc_len < VIRTQ_DESCRIPTOR_SIZE
+            || desc_len / VIRTQ_DESCRIPTOR_SIZE > std::u16::MAX as usize
+        {
+            return Err(Error::InvalidIndirectDescriptor);
+        }
+
+        // These reads can't fail unless Guest memory is hopelessly broken.
+        let desc: Descriptor = self
+            .mem
+            .get_slice(GuestAddress(desc_head), size_of::<Descriptor>())
+            .map(|s| s.get_ref(0).unwrap().load())
+            .map_err(|_| Error::GuestMemoryError)?;
+
+        let chain = DescriptorChain {
+            mem: self.mem.clone(),
+            desc_table: GuestAddress(desc_head),
+            queue_size: (desc_len / VIRTQ_DESCRIPTOR_SIZE) as u16,
+            ttl: (desc_len / VIRTQ_DESCRIPTOR_SIZE) as u16,
+            desc: Descriptor {
+                addr: desc.addr,
+                len: desc.len,
+                flags: desc.flags,
+                next: desc.next,
+            },
+        };
+
+        if !chain.is_valid() {
+            return Err(Error::InvalidChain);
+        }
+
+        Ok(chain)
     }
 
     fn is_valid(&self) -> bool {
@@ -154,6 +231,11 @@ impl<M: GuestAddressSpace> DescriptorChain<M> {
     /// Checks if this descriptor chain has another descriptor chain linked after it.
     pub fn has_next(&self) -> bool {
         self.desc.flags & VIRTQ_DESC_F_NEXT != 0 && self.ttl > 1
+    }
+
+    /// Checks if the descriptor is an indirect descriptor.
+    pub fn is_indirect(&self) -> bool {
+        self.desc.flags & VIRTQ_DESC_F_INDIRECT != 0
     }
 
     /// Return a `GuestMemory` object that can be used to access the buffers
@@ -506,8 +588,8 @@ pub(crate) mod tests {
 
     pub use super::*;
     use vm_memory::{
-        GuestAddress, GuestMemoryMmap, GuestMemoryRegion, VolatileMemory, VolatileRef,
-        VolatileSlice,
+        GuestAddress, GuestMemoryMmap, GuestMemoryRegion, MemoryRegionAddress, VolatileMemory,
+        VolatileRef, VolatileSlice,
     };
 
     // Represents a virtio descriptor in guest memory.
@@ -824,6 +906,73 @@ pub(crate) mod tests {
         assert!(
             DescriptorChain::<&GuestMemoryMmap>::checked_new(m, GuestAddress(0), 512, 1).is_some()
         );
+    }
+
+    #[test]
+    fn test_new_from_indirect_descriptor() {
+        let m = &GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
+        let vq = VirtQueue::new(GuestAddress(0), m, 16);
+
+        // create a chain with a descriptor pointing to an indirect table
+        let desc = vq.dtable(0);
+        desc.set(0x1000, 0x1000, VIRTQ_DESC_F_INDIRECT, 0);
+
+        let c: DescriptorChain<&GuestMemoryMmap> =
+            DescriptorChain::checked_new(m, vq.start(), 16, 0).unwrap();
+        assert!(c.is_indirect());
+
+        let region = m.find_region(GuestAddress(0)).unwrap();
+        let dtable = region
+            .get_slice(MemoryRegionAddress(0x1000u64), VirtqDesc::dtable_len(4))
+            .unwrap();
+        // create an indirect table with 4 chained descriptors
+        let mut indirect_table = Vec::with_capacity(4 as usize);
+        for j in 0..4 {
+            let desc = VirtqDesc::new(&dtable, j);
+            desc.set(0x1000, 0x1000, VIRTQ_DESC_F_NEXT, (j + 1) as u16);
+            indirect_table.push(desc);
+        }
+
+        // try to iterate through the indirect table descriptors
+        let mut i = c.new_from_indirect().unwrap();
+        for j in 0..4 {
+            let desc = i.next().unwrap();
+            assert_eq!(desc.flags(), VIRTQ_DESC_F_NEXT);
+            assert_eq!(desc.next, j + 1);
+        }
+    }
+
+    #[test]
+    fn test_new_from_indirect_descriptor_err() {
+        {
+            let m = &GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
+            let vq = VirtQueue::new(GuestAddress(0), m, 16);
+
+            // create a chain with a descriptor pointing to an indirect table
+            let desc = vq.dtable(0);
+            desc.set(0x1001, 0x1000, VIRTQ_DESC_F_INDIRECT, 0);
+
+            let c: DescriptorChain<&GuestMemoryMmap> =
+                DescriptorChain::checked_new(m, vq.start(), 16, 0).unwrap();
+            assert!(c.is_indirect());
+
+            assert!(c.new_from_indirect().is_err());
+        }
+
+        {
+            let m = &GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
+            let vq = VirtQueue::new(GuestAddress(0), m, 16);
+
+            // create a chain with a descriptor pointing to an indirect table
+            let desc = vq.dtable(0);
+            desc.set(0x1000, 0x1001, VIRTQ_DESC_F_INDIRECT, 0);
+
+            let c: DescriptorChain<&GuestMemoryMmap> =
+                DescriptorChain::checked_new(m, vq.start(), 16, 0).unwrap();
+            assert!(c.is_indirect());
+
+            assert!(c.new_from_indirect().is_err());
+        }
     }
 
     #[test]

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -454,8 +454,11 @@ pub struct Queue {
     /// The maximal size in elements offered by the device
     max_size: u16,
 
-    next_avail: Wrapping<u16>,
-    next_used: Wrapping<u16>,
+    /// The next available index
+    pub next_avail: Wrapping<u16>,
+
+    /// The next used index
+    pub next_used: Wrapping<u16>,
 
     /// Notification from driver is enabled.
     event_notification_enabled: bool,

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -14,7 +14,7 @@ use std::cmp::min;
 use std::fmt::{self, Display};
 use std::mem::size_of;
 use std::num::Wrapping;
-use std::sync::atomic::{fence, Ordering};
+use std::sync::atomic::{fence, AtomicU16, Ordering};
 
 use vm_memory::{
     Address, ByteValued, Bytes, GuestAddress, GuestAddressSpace, GuestMemory, GuestUsize,
@@ -32,6 +32,8 @@ const VIRTQ_USED_RING_HEADER_SIZE: usize = 4;
 // The total size of the used ring is:
 // VIRTQ_USED_RING_HMETA_SIZE + VIRTQ_USED_ELEMENT_SIZE * queue_size
 const VIRTQ_USED_RING_META_SIZE: usize = VIRTQ_USED_RING_HEADER_SIZE + 2;
+// Used flags
+const VIRTQ_USED_F_NO_NOTIFY: u16 = 0x1;
 
 const VIRTQ_AVAIL_ELEMENT_SIZE: usize = 2;
 // Avail ring header: flags(u16) + idx(u16)
@@ -441,6 +443,15 @@ pub struct Queue<M: GuestAddressSpace> {
     next_avail: Wrapping<u16>,
     next_used: Wrapping<u16>,
 
+    /// Notification from driver is enabled.
+    event_notification_enabled: bool,
+
+    /// VIRTIO_F_RING_EVENT_IDX negotiated
+    event_idx_enabled: bool,
+
+    /// The last used value when using EVENT_IDX
+    signalled_used: Option<Wrapping<u16>>,
+
     /// The queue size in elements the driver selected
     pub size: u16,
 
@@ -470,6 +481,9 @@ impl<M: GuestAddressSpace> Queue<M> {
             used_ring: GuestAddress(0),
             next_avail: Wrapping(0),
             next_used: Wrapping(0),
+            event_notification_enabled: true,
+            event_idx_enabled: false,
+            signalled_used: None,
         }
     }
 
@@ -488,6 +502,13 @@ impl<M: GuestAddressSpace> Queue<M> {
     pub fn reset(&mut self) {
         self.ready = false;
         self.size = self.max_size;
+    }
+
+    /// Enable/disable the VIRTIO_F_RING_EVENT_IDX feature.
+    pub fn set_event_idx(&mut self, enabled: bool) {
+        /* Also reset the last signalled event */
+        self.signalled_used = None;
+        self.event_idx_enabled = enabled;
     }
 
     /// Check if the virtio queue configuration is valid.
@@ -583,13 +604,13 @@ impl<M: GuestAddressSpace> Queue<M> {
     }
 
     /// Puts an available descriptor head into the used ring for use by the guest.
-    pub fn add_used(&mut self, desc_index: u16, len: u32) {
+    pub fn add_used(&mut self, desc_index: u16, len: u32) -> Option<u16> {
         if desc_index >= self.actual_size() {
             error!(
                 "attempted to add out of bounds descriptor to used ring: {}",
                 desc_index
             );
-            return;
+            return None;
         }
 
         let snapshot = self.mem.memory();
@@ -614,6 +635,138 @@ impl<M: GuestAddressSpace> Queue<M> {
         snapshot
             .write_obj(self.next_used.0 as u16, used_ring.unchecked_add(2))
             .unwrap();
+
+        Some(self.next_used.0)
+    }
+
+    /// Update avail_event on the used ring with the last index in the avail ring.
+    ///
+    /// The device can suppress notifications in a manner analogous to the way drivers can suppress
+    /// interrupts. The device manipulates flags or avail_event in the used ring the same way the
+    /// driver manipulates flags or used_event in the available ring.
+    ///
+    /// The device MAY use avail_event to advise the driver that notifications are unnecessary until
+    /// the driver writes entry with an index specified by avail_event into the available ring
+    /// (equivalently, until idx in the available ring will reach the value avail_event + 1).
+    fn update_avail_event(&mut self) {
+        // Safe because we have validated the queue and access guest memory through GuestMemory
+        // interfaces.
+        // And the `used_index` is a two-byte naturally aligned field, so it won't cross the region
+        // boundary and get_slice() shouldn't fail.
+        let mem = self.mem.memory();
+        let index_addr = self.avail_ring.unchecked_add(2);
+        match mem.get_slice(index_addr, size_of::<u16>()).map(|s| {
+            s.get_atomic_ref::<AtomicU16>(0)
+                .unwrap()
+                .load(Ordering::Relaxed)
+        }) {
+            Ok(index) => {
+                let offset = (4 + self.actual_size() * 8) as u64;
+                let avail_event_addr = self.used_ring.unchecked_add(offset);
+                if let Ok(avail_event_slice) = mem.get_slice(avail_event_addr, size_of::<u16>()) {
+                    avail_event_slice
+                        .get_atomic_ref::<AtomicU16>(0)
+                        .unwrap()
+                        .store(index, Ordering::Relaxed);
+                } else {
+                    warn!("Can't update avail_event");
+                }
+            }
+            Err(e) => warn!("Invalid offset, {}", e),
+        }
+    }
+
+    fn update_used_flag(&mut self, set: u16, clr: u16) {
+        // Safe because we have validated the queue and access guest memory through GuestMemory
+        // interfaces.
+        // And the `used_index` is a two-byte naturally aligned field, so it won't cross the region
+        // boundary and get_slice() shouldn't fail.
+        let mem = self.mem.memory();
+        let slice = mem
+            .get_slice(self.used_ring, size_of::<u16>())
+            .expect("invalid address for virtq_used.flags");
+        let flag = slice.get_atomic_ref::<AtomicU16>(0).unwrap();
+        let v = flag.load(Ordering::Relaxed);
+
+        flag.store((v & !clr) | set, Ordering::Relaxed);
+    }
+
+    fn set_notification(&mut self, enable: bool) {
+        self.event_notification_enabled = enable;
+        if self.event_notification_enabled {
+            if self.event_idx_enabled {
+                self.update_avail_event();
+            } else {
+                self.update_used_flag(0, VIRTQ_USED_F_NO_NOTIFY);
+            }
+
+            // This fence ensures that we observe the latest of virtq_avail once we publish
+            // virtq_used.avail_event/virtq_used.flags.
+            fence(Ordering::AcqRel);
+        } else if !self.event_idx_enabled {
+            self.update_used_flag(VIRTQ_USED_F_NO_NOTIFY, 0);
+        }
+    }
+
+    /// Enable notification events from the guest driver.
+    #[inline]
+    pub fn enable_notification(&mut self) {
+        self.set_notification(true);
+    }
+
+    /// Disable notification events from the guest driver.
+    #[inline]
+    pub fn disable_notification(&mut self) {
+        self.set_notification(false);
+    }
+
+    /// Return the value present in the used_event field of the avail ring.
+    ///
+    /// If the VIRTIO_F_EVENT_IDX feature bit is not negotiated, the flags field in the available
+    /// ring offers a crude mechanism for the driver to inform the device that it doesn’t want
+    /// interrupts when buffers are used. Otherwise virtq_avail.used_event is a more performant
+    /// alternative where the driver specifies how far the device can progress before interrupting.
+    ///
+    /// Neither of these interrupt suppression methods are reliable, as they are not synchronized
+    /// with the device, but they serve as useful optimizations. So we only ensure access to the
+    /// virtq_avail.used_event is atomic, but do not need to synchronize with other memory accesses.
+    fn get_used_event(&self) -> Option<Wrapping<u16>> {
+        // Safe because we have validated the queue and access guest memory through GuestMemory
+        // interfaces.
+        // And the `used_index` is a two-byte naturally aligned field, so it won't cross the region
+        // boundary and get_slice() shouldn't fail.
+        let mem = self.mem.memory();
+        let used_event_addr = self
+            .avail_ring
+            .unchecked_add((4 + self.actual_size() * 2) as u64);
+
+        mem.get_slice(used_event_addr, size_of::<u16>())
+            .map(|s| {
+                Wrapping(
+                    s.get_atomic_ref::<AtomicU16>(0)
+                        .unwrap()
+                        .load(Ordering::Relaxed),
+                )
+            })
+            .ok()
+    }
+
+    /// Check whether a notification to the guest is needed.
+    pub fn needs_notification(&mut self, used_idx: Wrapping<u16>) -> bool {
+        let mut notify = true;
+
+        // The VRING_AVAIL_F_NO_INTERRUPT flag isn't supported yet.
+        if self.event_idx_enabled {
+            if let Some(old_idx) = self.signalled_used.replace(used_idx) {
+                if let Some(used_event) = self.get_used_event() {
+                    if (used_idx - used_event - Wrapping(1u16)) >= (used_idx - old_idx) {
+                        notify = false;
+                    }
+                }
+            }
+        }
+
+        notify
     }
 
     /// Goes back one position in the available descriptor chain offered by the driver.
@@ -1229,11 +1382,11 @@ pub(crate) mod tests {
         assert_eq!(vq.used.idx().load(), 0);
 
         //index too large
-        q.add_used(16, 0x1000);
+        assert!(q.add_used(16, 0x1000).is_none());
         assert_eq!(vq.used.idx().load(), 0);
 
         //should be ok
-        q.add_used(1, 0x1000);
+        assert_eq!(q.add_used(1, 0x1000).unwrap(), 1);
         assert_eq!(vq.used.idx().load(), 1);
         let x = vq.used.ring(0).load();
         assert_eq!(x.id, 1);
@@ -1251,5 +1404,87 @@ pub(crate) mod tests {
         q.reset();
         assert_eq!(q.size, 16);
         assert_eq!(q.ready, false);
+    }
+
+    #[test]
+    fn test_needs_notification() {
+        let m = &GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
+        let vq = VirtQueue::new(GuestAddress(0), m, 16);
+        let mut q = vq.create_queue(&m);
+        let avail_addr = vq.avail_start();
+
+        // It should always return true when EVENT_IDX isn't enabled.
+        assert_eq!(q.needs_notification(Wrapping(1)), true);
+        assert_eq!(q.needs_notification(Wrapping(2)), true);
+        assert_eq!(q.needs_notification(Wrapping(3)), true);
+        assert_eq!(q.needs_notification(Wrapping(4)), true);
+        assert_eq!(q.needs_notification(Wrapping(5)), true);
+
+        m.write_obj::<u16>(4, avail_addr.unchecked_add(4 + 16 * 2))
+            .unwrap();
+        q.set_event_idx(true);
+        assert_eq!(q.needs_notification(Wrapping(1)), true);
+        assert_eq!(q.needs_notification(Wrapping(2)), false);
+        assert_eq!(q.needs_notification(Wrapping(3)), false);
+        assert_eq!(q.needs_notification(Wrapping(4)), false);
+        assert_eq!(q.needs_notification(Wrapping(5)), true);
+        assert_eq!(q.needs_notification(Wrapping(6)), false);
+        assert_eq!(q.needs_notification(Wrapping(7)), false);
+
+        m.write_obj::<u16>(8, avail_addr.unchecked_add(4 + 16 * 2))
+            .unwrap();
+        assert_eq!(q.needs_notification(Wrapping(11)), true);
+        assert_eq!(q.needs_notification(Wrapping(12)), false);
+
+        m.write_obj::<u16>(15, avail_addr.unchecked_add(4 + 16 * 2))
+            .unwrap();
+        assert_eq!(q.needs_notification(Wrapping(0)), true);
+        assert_eq!(q.needs_notification(Wrapping(14)), false);
+    }
+
+    #[test]
+    fn test_enable_disable_notification() {
+        let m = &GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
+        let vq = VirtQueue::new(GuestAddress(0), m, 16);
+        let mut q = vq.create_queue(&m);
+        let used_addr = vq.used_start();
+
+        assert_eq!(q.event_notification_enabled, true);
+        assert_eq!(q.event_idx_enabled, false);
+
+        q.enable_notification();
+        let v = m.read_obj::<u16>(used_addr).unwrap();
+        assert_eq!(v, 0);
+
+        q.disable_notification();
+        let v = m.read_obj::<u16>(used_addr).unwrap();
+        assert_eq!(v, VIRTQ_USED_F_NO_NOTIFY);
+
+        q.enable_notification();
+        let v = m.read_obj::<u16>(used_addr).unwrap();
+        assert_eq!(v, 0);
+
+        q.set_event_idx(true);
+        let avail_addr = vq.avail_start();
+        m.write_obj::<u16>(2, avail_addr.unchecked_add(2)).unwrap();
+
+        q.enable_notification();
+        let v = m
+            .read_obj::<u16>(used_addr.unchecked_add(4 + 8 * 16))
+            .unwrap();
+        assert_eq!(v, 2);
+
+        q.disable_notification();
+        let v = m
+            .read_obj::<u16>(used_addr.unchecked_add(4 + 8 * 16))
+            .unwrap();
+        assert_eq!(v, 2);
+
+        m.write_obj::<u16>(8, avail_addr.unchecked_add(2)).unwrap();
+        q.enable_notification();
+        let v = m
+            .read_obj::<u16>(used_addr.unchecked_add(4 + 8 * 16))
+            .unwrap();
+        assert_eq!(v, 8);
     }
 }

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -161,6 +161,22 @@ impl<M: GuestAddressSpace> DescriptorChain<M> {
     pub fn memory(&self) -> &M::M {
         &*self.mem
     }
+
+    /// Returns an iterator that only yields the readable descriptors in the chain.
+    pub fn readable(self) -> DescriptorChainRwIter<M> {
+        DescriptorChainRwIter {
+            chain: self,
+            writable: false,
+        }
+    }
+
+    /// Returns an iterator that only yields the writable descriptors in the chain.
+    pub fn writable(self) -> DescriptorChainRwIter<M> {
+        DescriptorChainRwIter {
+            chain: self,
+            writable: true,
+        }
+    }
 }
 
 impl<M: GuestAddressSpace> Iterator for DescriptorChain<M> {
@@ -190,6 +206,34 @@ impl<M: GuestAddressSpace> Iterator for DescriptorChain<M> {
             self.ttl -= 1;
         }
         Some(curr)
+    }
+}
+
+/// An iterator for readable or writable descriptors.
+pub struct DescriptorChainRwIter<M: GuestAddressSpace> {
+    chain: DescriptorChain<M>,
+    writable: bool,
+}
+
+impl<M: GuestAddressSpace> Iterator for DescriptorChainRwIter<M> {
+    type Item = Descriptor;
+
+    /// Returns the next descriptor in this descriptor chain, if there is one.
+    ///
+    /// Note that this is distinct from the next descriptor chain returned by
+    /// [`AvailIter`](struct.AvailIter.html), which is the head of the next
+    /// _available_ descriptor chain.
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            match self.chain.next() {
+                Some(v) => {
+                    if v.is_write_only() == self.writable {
+                        return Some(v);
+                    }
+                }
+                None => return None,
+            }
+        }
     }
 }
 
@@ -890,6 +934,69 @@ pub(crate) mod tests {
             c.next().unwrap();
             assert!(!c.has_next());
             assert!(c.next().is_none());
+        }
+    }
+
+    #[test]
+    fn test_descriptor_and_iterator() {
+        let m = &GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
+        let vq = VirtQueue::new(GuestAddress(0), m, 16);
+
+        let mut q = vq.create_queue(m);
+
+        // q is currently valid
+        assert!(q.is_valid());
+
+        for j in 0..7 {
+            vq.dtable(j).set(
+                0x1000 * (j + 1) as u64,
+                0x1000,
+                VIRTQ_DESC_F_NEXT,
+                (j + 1) as u16,
+            );
+        }
+
+        // the chains are (0, 1), (2, 3, 4) and (5, 6)
+        vq.dtable(1).flags().store(0);
+        vq.dtable(2)
+            .flags()
+            .store(VIRTQ_DESC_F_NEXT | VIRTQ_DESC_F_WRITE);
+        vq.dtable(4).flags().store(VIRTQ_DESC_F_WRITE);
+        vq.dtable(5)
+            .flags()
+            .store(VIRTQ_DESC_F_NEXT | VIRTQ_DESC_F_WRITE);
+        vq.dtable(6).flags().store(0);
+        vq.avail.ring(0).store(0);
+        vq.avail.ring(1).store(2);
+        vq.avail.ring(2).store(5);
+        vq.avail.idx().store(3);
+
+        let mut i = q.iter();
+
+        {
+            let c = i.next().unwrap();
+            let mut iter = c.into_iter();
+            assert!(iter.next().is_some());
+            assert!(iter.next().is_some());
+            assert!(iter.next().is_none());
+            assert!(iter.next().is_none());
+        }
+
+        {
+            let c = i.next().unwrap();
+            let mut iter = c.writable();
+            assert!(iter.next().is_some());
+            assert!(iter.next().is_some());
+            assert!(iter.next().is_none());
+            assert!(iter.next().is_none());
+        }
+
+        {
+            let c = i.next().unwrap();
+            let mut iter = c.readable();
+            assert!(iter.next().is_some());
+            assert!(iter.next().is_none());
+            assert!(iter.next().is_none());
         }
     }
 

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -182,7 +182,7 @@ impl<'a, M: GuestMemory> DescriptorChain<'a, M> {
     }
 
     /// Create a new DescriptorChain instance.
-    fn checked_new(
+    pub fn checked_new(
         mem: &'a M,
         dtable_addr: GuestAddress,
         queue_size: u16,
@@ -351,6 +351,22 @@ impl<'a, M: GuestMemory> Iterator for DescriptorChain<'a, M> {
             self.has_next = curr.has_next();
 
             Some(curr)
+        }
+    }
+}
+
+impl<'a, M: GuestMemory> Clone for DescriptorChain<'a, M> {
+    fn clone(&self) -> Self {
+        DescriptorChain {
+            mem: self.mem,
+            desc_table: self.desc_table,
+            queue_size: self.queue_size,
+            ttl: self.ttl,
+            index: self.index,
+            desc: self.desc,
+            curr_indirect: self.curr_indirect.clone(),
+            is_master: self.is_master,
+            has_next: self.has_next,
         }
     }
 }
@@ -1196,6 +1212,7 @@ pub(crate) mod tests {
                 assert_eq!(desc.flags(), VIRTQ_DESC_F_NEXT);
                 assert_eq!(desc.next, j + 1);
                 assert!(c.has_next());
+                assert_eq!(c.index(), 0);
             }
         }
 

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -403,19 +403,13 @@ impl<'b, M: GuestAddressSpace> Iterator for AvailIter<'b, M> {
         let offset = (VIRTQ_AVAIL_RING_HEADER_SIZE as u16
             + (self.next_index.0 % self.queue_size) * VIRTQ_AVAIL_ELEMENT_SIZE as u16)
             as usize;
-        let avail_addr = match self.mem.checked_offset(self.avail_ring, offset) {
-            Some(a) => a,
-            None => return None,
-        };
+        let avail_addr = self.avail_ring.checked_add(offset as u64)?;
         // This index is checked below in checked_new
-        let desc_index: u16 = match self.mem.read_obj(avail_addr) {
-            Ok(ret) => ret,
-            Err(_) => {
-                // TODO log address
-                error!("Failed to read from memory");
-                return None;
-            }
-        };
+        let desc_index: u16 = self
+            .mem
+            .read_obj(avail_addr)
+            .map_err(|_e| error!("Failed to read from memory {:x}", avail_addr.raw_value()))
+            .ok()?;
 
         self.next_index += Wrapping(1);
 
@@ -513,7 +507,7 @@ impl<M: GuestAddressSpace> Queue<M> {
 
     /// Check if the virtio queue configuration is valid.
     pub fn is_valid(&self) -> bool {
-        let snapshot = self.mem.memory();
+        let mem = self.mem.memory();
         let queue_size = self.actual_size() as usize;
         let desc_table = self.desc_table;
         let desc_table_size = size_of::<Descriptor>() * queue_size;
@@ -530,7 +524,7 @@ impl<M: GuestAddressSpace> Queue<M> {
             false
         } else if desc_table
             .checked_add(desc_table_size as GuestUsize)
-            .map_or(true, |v| !snapshot.address_in_range(v))
+            .map_or(true, |v| !mem.address_in_range(v))
         {
             error!(
                 "virtio queue descriptor table goes out of bounds: start:0x{:08x} size:0x{:08x}",
@@ -540,7 +534,7 @@ impl<M: GuestAddressSpace> Queue<M> {
             false
         } else if avail_ring
             .checked_add(avail_ring_size as GuestUsize)
-            .map_or(true, |v| !snapshot.address_in_range(v))
+            .map_or(true, |v| !mem.address_in_range(v))
         {
             error!(
                 "virtio queue available ring goes out of bounds: start:0x{:08x} size:0x{:08x}",
@@ -550,7 +544,7 @@ impl<M: GuestAddressSpace> Queue<M> {
             false
         } else if used_ring
             .checked_add(used_ring_size as GuestUsize)
-            .map_or(true, |v| !snapshot.address_in_range(v))
+            .map_or(true, |v| !mem.address_in_range(v))
         {
             error!(
                 "virtio queue used ring goes out of bounds: start:0x{:08x} size:0x{:08x}",
@@ -577,23 +571,22 @@ impl<M: GuestAddressSpace> Queue<M> {
         let queue_size = self.actual_size();
         let avail_ring = self.avail_ring;
 
-        let snapshot = self.mem.memory();
-        let index_addr = match snapshot.checked_offset(avail_ring, 2) {
+        let mem = self.mem.memory();
+        let index_addr = match avail_ring.checked_add(2) {
             Some(ret) => ret,
             None => {
-                // TODO log address
-                warn!("Invalid offset");
-                return AvailIter::new(snapshot, &mut self.next_avail);
+                warn!("Invalid offset {}", avail_ring.raw_value());
+                return AvailIter::new(mem, &mut self.next_avail);
             }
         };
         // Note that last_index has no invalid values
-        let last_index: u16 = match snapshot.read_obj::<u16>(index_addr) {
+        let last_index: u16 = match mem.read_obj::<u16>(index_addr) {
             Ok(ret) => ret,
-            Err(_) => return AvailIter::new(snapshot, &mut self.next_avail),
+            Err(_) => return AvailIter::new(mem, &mut self.next_avail),
         };
 
         AvailIter {
-            mem: snapshot,
+            mem,
             desc_table: self.desc_table,
             avail_ring,
             next_index: self.next_avail,
@@ -613,17 +606,14 @@ impl<M: GuestAddressSpace> Queue<M> {
             return None;
         }
 
-        let snapshot = self.mem.memory();
+        let mem = self.mem.memory();
         let used_ring = self.used_ring;
         let next_used = u64::from(self.next_used.0 % self.actual_size());
         let used_elem = used_ring.unchecked_add(4 + next_used * 8);
 
         // These writes can't fail as we are guaranteed to be within the descriptor ring.
-        snapshot
-            .write_obj(u32::from(desc_index), used_elem)
-            .unwrap();
-        snapshot
-            .write_obj(len as u32, used_elem.unchecked_add(4))
+        mem.write_obj(u32::from(desc_index), used_elem).unwrap();
+        mem.write_obj(len as u32, used_elem.unchecked_add(4))
             .unwrap();
 
         self.next_used += Wrapping(1);
@@ -632,8 +622,7 @@ impl<M: GuestAddressSpace> Queue<M> {
         fence(Ordering::Release);
 
         // We are guaranteed to be within the used ring, this write can't fail.
-        snapshot
-            .write_obj(self.next_used.0 as u16, used_ring.unchecked_add(2))
+        mem.write_obj(self.next_used.0, used_ring.unchecked_add(2))
             .unwrap();
 
         Some(self.next_used.0)

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -37,7 +37,7 @@ const VIRTQ_AVAIL_RING_META_SIZE: usize = VIRTQ_AVAIL_RING_HEADER_SIZE + 2;
 
 // GuestMemory::read_obj() will be used to fetch the descriptor,
 // which has an explicit constraint that the entire descriptor doesn't
-// cross the page boundary. Otherwise the descriptor may be splitted into
+// cross the page boundary. Otherwise the descriptor may be split into
 // two mmap regions which causes failure of GuestMemory::read_obj().
 //
 // The Virtio Spec 1.0 defines the alignment of VirtIO descriptor is 16 bytes,
@@ -112,12 +112,14 @@ impl<M: GuestAddressSpace> DescriptorChain<M> {
             return None;
         }
 
-        let desc_table_size = size_of::<Descriptor>() * queue_size as usize;
-        let slice = mem.get_slice(desc_table, desc_table_size).ok()?;
-        let desc = slice
-            .get_array_ref(0, queue_size as usize)
-            .ok()?
-            .load(index as usize);
+        let desc_size = size_of::<Descriptor>();
+        let desc_addr = match desc_table.checked_add(desc_size as u64 * index as u64) {
+            Some(a) => a,
+            None => return None,
+        };
+        // The descriptor is 16 bytes and aligned on on 16-bytes, so it won't cross guest memory boundary.
+        let slice = mem.get_slice(desc_addr, desc_size).ok()?;
+        let desc = slice.get_ref(0).ok()?.load();
         let chain = DescriptorChain {
             mem,
             desc_table,
@@ -758,6 +760,20 @@ pub(crate) mod tests {
             assert!(c.next().is_some());
             assert!(c.next().is_none());
         }
+    }
+
+    #[test]
+    fn test_checked_new_descriptor_chain_cross_mem_region() {
+        let m = &GuestMemoryMmap::from_ranges(&[
+            (GuestAddress(0), 0x1000),
+            (GuestAddress(0x1000), 0x1000),
+        ])
+        .unwrap();
+
+        // The whole descriptor table crosses guest memory boundary, it should ok.
+        assert!(
+            DescriptorChain::<&GuestMemoryMmap>::checked_new(m, GuestAddress(0), 512, 1).is_some()
+        );
     }
 
     #[test]


### PR DESCRIPTION
This patch set aims to enhance the vm-virtio crate to better support fuse/virtiofs related projects.
The first ten patches have been submitted to rust-vmm/vm-virtio, and the last four patches may be hold  for a while until we reach an agreement in the rust-vmm community.