### PR TITLE
update vm-memory version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,9 @@ edition = "2018"
 byteorder = "=1.2.1"
 libc = ">=0.2.39"
 log = "=0.4.6"
-vm-memory = {version = ">=0.2.0", features = ["integer-atomics"] }
+vm-memory = { version = ">=0.4.0" }
 vmm-sys-util = ">=0.4.0"
 
 [dev-dependencies.vm-memory]
-version = ">=0.2.0"
-features = ["backend-mmap", "integer-atomics"]
+version = ">=0.4.0"
+features = ["backend-mmap"]


### PR DESCRIPTION
vm-memory 0.3.0 has removed integer-atomics as distinct feature.

Signed-off-by: Liu Bo <bo.liu@linux.alibaba.com>